### PR TITLE
Adding path checking to prevent symlink loop

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,7 @@ machine:
 
 dependencies:
     pre:
+        - pip install pip==9.0.3
         - pip install --upgrade setuptools
         - pip install --upgrade virtualenv
         - sudo mkdir /usr/local/lib/yotta_modules

--- a/kubos/utils/sdk_utils.py
+++ b/kubos/utils/sdk_utils.py
@@ -69,6 +69,13 @@ def link_entities(src, dst):
     logging.disable(logging.WARNING) #suppress yotta warning for linking non-required modules and targets
     for subdir in os.listdir(src):
         #loop through the subdirectories of src
+        #but don't go down the rabbit hole of yotta_module symlinks
+        if "yotta_modules" in subdir:
+            continue
+        if "yotta_targets" in subdir:
+            continue
+        if "build" in subdir:
+            continue
         cur_dir = os.path.join(src, subdir)
         if is_module_or_target_root(subdir):
             #if we're pointing to a target.json or module.json - link the module and return


### PR DESCRIPTION
Building a yotta module within the copy of the kubos repo which is being used as the source code (set by running the kubos repo's `tools/kubos_link.py` script) causes a blackhole of nested symlinks in the `/usr/lib/local/yotta_modules` directory for that module.

This PR keeps the `kubos link -a` command from travelling down the rabbit hole by stopping if a sub-directory is named `yotta_modules` or `yotta_target` (also `build` because it's not relevant to linking so we might as well not traverse it)